### PR TITLE
Allowing deserialize() to parse multiple transactions at once

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -448,71 +448,90 @@ TransactionOut.prototype.clone = function() {
   return newTxout;
 };
 
-Transaction.deserialize = function(buf) {
+// Second argument txCount is optional; It indicates
+// the number of the transactions that you expect to
+// parse. The default number is 1
+Transaction.deserialize = function(buf, txCount) {
   if (!Buffer.isBuffer(buf)) {
     buf = binConv(buf, {
       out: 'buffer'
     });
   }
 
-  var doc = {};
   var s = new Parser(buf)
 
-  doc.version = s.readUInt32LE()
-
-  doc.ins = []
-  doc.outs = []
-
-  var inputCount = s.readVarInt()
-  for (var i = 0; i < inputCount; i++) {
-    var data = {}
-    data.outpoint = {}
-
-    var txHash = s.raw(32)
-    if (txHash === false) {
-      return false
-    }
-
-    // TODO: change this to buffer in the transition to buffer
-    data.outpoint.hash = binConv(binConv(txHash, {
-      out: 'bytes'
-    }).reverse(), {
-      out: 'hex'
-    })
-
-    data.outpoint.index = s.readUInt32LE()
-
-    var scriptLength = s.readVarInt()
-    data.script = new Script(s.raw(scriptLength).toString('hex'))
-
-    data.sequence = s.readUInt32LE()
-
-    doc.ins.push(data)
+  if (!txCount) {
+    txCount = 1;
   }
 
-  var outputCount = s.readVarInt()
-  for (var i = 0; i < outputCount; i++) {
-    var data = {}
-    var value = s.raw(8)
-    if (value === false) {
-      return false
+  var transactions = []
+  for (var y = 0; y < txCount; y++) {
+    var doc = {};
+
+    doc.version = s.readUInt32LE()
+
+    doc.ins = []
+    doc.outs = []
+
+    var inputCount = s.readVarInt()
+    for (var i = 0; i < inputCount; i++) {
+      var data = {}
+      data.outpoint = {}
+
+      var txHash = s.raw(32)
+      if (txHash === false) {
+        return false
+      }
+
+      // TODO: change this to buffer in the transition to buffer
+      data.outpoint.hash = binConv(binConv(txHash, {
+        out: 'bytes'
+      }).reverse(), {
+        out: 'hex'
+      })
+
+      data.outpoint.index = s.readUInt32LE()
+
+      var scriptLength = s.readVarInt()
+      data.script = new Script(s.raw(scriptLength).toString('hex'))
+      data.sequence = s.readUInt32LE()
+
+      doc.ins.push(data)
     }
 
-    data.value = binConv(value, {
-      out: 'bytes'
-    })
+    var outputCount = s.readVarInt()
+    for (var i = 0; i < outputCount; i++) {
+      var data = {}
+      var value = s.raw(8)
+      if (value === false) {
+        return false
+      }
 
-    var scriptLength = s.readVarInt()
-    data.script = new Script(s.raw(scriptLength).toString('hex'))
+      data.value = binConv(value, {
+        out: 'bytes'
+      })
 
-    doc.outs.push(data)
+      var scriptLength = s.readVarInt()
+      data.script = new Script(s.raw(scriptLength).toString('hex'))
+
+      doc.outs.push(data)
+    }
+
+    doc.lock_time = s.readUInt32LE()
+    if (s.hasFailed) {
+      return false
+    } else {
+      transactions.push(new Transaction(doc))
+    }
   }
 
-  doc.lock_time = s.readUInt32LE()
   if (s.hasFailed) {
     return false
-  } else {
-    return new Transaction(doc)
   }
 
+  if (txCount === 1) {
+    return transactions[0]
+  } else {
+    return transactions
+  }
 }

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -31,5 +31,33 @@ describe('Transaction ', function() {
       var test = Transaction.deserialize(buf)
       F(test, 'this should return false')
     })
+
+    it(' > able to parse multiple transcations', function() {
+      // note: tx 1 b1fea52486ce0c62bb442b530a3f0132b826c74e473d1f2c220bfa78111c5082
+      // note: tx 2 f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16
+
+      var twoRawHex = '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0102ffffffff0100f2052a01000000434104d46c4968bde02899d2aa0963367c7a6ce34eec332b32e42e5f3407e052d64ac625da6f0718e7b302140434bd725706957c092db53805b821a85b23a7ac61725bac000000000100000001c997a5e56e104102fa209c6a852dd90660a20b2d9c352423edce25857fcd3704000000004847304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901ffffffff0200ca9a3b00000000434104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac00286bee0000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac00000000'
+
+      var buf = convBin(twoRawHex, { in : 'hex',
+        out: 'buffer'
+      })
+      var test = Transaction.deserialize(buf, 2)
+      T(test, 'this should not return false')
+      T(Array.isArray(test), 'this should return an Array of transaction objects')
+
+      if (test) {
+        EQ(test.length, 2)
+        T(test[0] instanceof Transaction)
+        T(test[1] instanceof Transaction)
+        EQ(test[0].version, 1)
+        EQ(test[1].version, 1)
+        EQ(test[0].lock_time, 0)
+        EQ(test[1].lock_time, 0)
+        EQ(test[0].ins.length, 1)
+        EQ(test[1].ins.length, 1)
+        EQ(test[0].outs.length, 1)
+        EQ(test[1].outs.length, 2)
+      }
+    })
   })
 })


### PR DESCRIPTION
In this pull request, I would like to introduce the ability to parse multiple transactions specified by the user. This is useful for parsing network messages / block messages etc

The test uses these two transactions:
https://helloblock.io/mainnet/transactions/b1fea52486ce0c62bb442b530a3f0132b826c74e473d1f2c220bfa78111c5082
https://helloblock.io/mainnet/transactions/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16
