### PR TITLE
TransactionIn is able to accept coinbase TranscationIns (no prev out)

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -399,7 +399,20 @@ Transaction.prototype.getTotalOutValue = function() {
 Transaction.prototype.getTotalValue = Transaction.prototype.getTotalOutValue;
 
 function TransactionIn(data) {
+  // if prevout hash is null
+  // then this is a coinbase transaction
+  // Note: we can never have a null hash, this makes serilization of the transaction impossible
+  if (!data.outpoint) {
+    data.outpoint = {}
+  }
+
+  if (!data.outpoint.hash) {
+    data.outpoint.hash = '0000000000000000000000000000000000000000000000000000000000000000'
+    data.outpoint.index = -1
+  }
+
   this.outpoint = data.outpoint;
+
   if (data.script instanceof Script) {
     this.script = data.script;
   } else {

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -1,4 +1,5 @@
 var Transaction = require('../').Transaction
+var TransactionIn = require('../').TransactionIn
 var TransactionOut = require('../').TransactionOut
 var BigInteger = require('bigi')
 var convBin = require('binstring')
@@ -74,7 +75,37 @@ describe('Transaction ', function() {
       T(test.getTotalOutValue().compareTo(BigInteger('30000000000', 10)) === 0)
     })
   })
+})
 
+describe('TransactionIn', function() {
+  describe(' - new TransactionIn()', function() {
+    it(' > Should be able to generate a coinbase TranscationIn', function() {
+      // Genesis Coinbase Transaction
+      // https://helloblock.io/mainnet/transactions/0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098
+
+      // scenario 1:
+      // there is outpoint but there is no hash
+      var coinbaseInput1 = new TransactionIn({
+        outpoint: {
+          hash: null,
+          index: null
+        },
+        script: '04ffff001d0104'
+      })
+
+      EQ(coinbaseInput1.outpoint.hash, '0000000000000000000000000000000000000000000000000000000000000000')
+      EQ(coinbaseInput1.outpoint.index, -1)
+
+      // scenario 2:
+      // there no outpoint
+      var coinbaseInput2 = new TransactionIn({
+        script: '04ffff001d0104'
+      })
+
+      EQ(coinbaseInput2.outpoint.hash, '0000000000000000000000000000000000000000000000000000000000000000')
+      EQ(coinbaseInput2.outpoint.index, -1)
+    })
+  })
 })
 
 describe('TransactionOut', function() {


### PR DESCRIPTION
If the user does not pass in outpoint data (for example if you use the blockchain.info api)

There are apis that consider coinbase to have tx_hash of null. If a user uses those api to generate a TransactionIn, the user will run into the problems. 

This pull request checks for the existence of prev_out, and if a txin does not reference a txout, it will assign coinbase tx hash and tx index to it (which is 32 zero bytes and index of -1 or 0xffffffff)
