### PR TITLE
Bugfix deserialize v2 block

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -69,7 +69,7 @@ function Transaction(doc) {
 
   if (doc) {
     if (doc.hash) this.hash = doc.hash;
-    if (doc.version) this.version = doc.version;
+    if (doc.version !== null) this.version = doc.version;
     if (doc.lock_time) this.lock_time = doc.lock_time;
     if (doc.ins && doc.ins.length) {
       for (var i = 0; i < doc.ins.length; i++) {
@@ -432,7 +432,6 @@ Transaction.deserialize = function(buf, txCount) {
   var transactions = []
   for (var y = 0; y < txCount; y++) {
     var doc = {};
-
     doc.version = s.readUInt32LE()
 
     doc.ins = []

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -455,10 +455,11 @@ Transaction.deserialize = function(buf, txCount) {
         out: 'hex'
       })
 
+      isCoinbase = (data.outpoint.hash === '0000000000000000000000000000000000000000000000000000000000000000')
       data.outpoint.index = s.readUInt32LE()
 
       var scriptLength = s.readVarInt()
-      data.script = new Script(s.raw(scriptLength).toString('hex'))
+      data.script = new Script(s.raw(scriptLength).toString('hex'), isCoinbase)
       data.sequence = s.readUInt32LE()
 
       doc.ins.push(data)

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -70,6 +70,16 @@ describe('Transaction ', function() {
         EQ(test[1].outs.length, 2)
       }
     })
+
+    it(' > supports BIP34 coinbase transactions', function() {
+      var coinbaseHex = '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0d03d891000450a8eb0b4ed20100ffffffff0100f2052a010000001976a9148c91773ffc9541c8f871ba62d3e7df2c54eddd7488ac00000000'
+      var buf = convBin(coinbaseHex, { in : 'hex',
+        out: 'buffer'
+      })
+      var v2coinbaseTx = Transaction.deserialize(buf)
+      T(v2coinbaseTx)
+      EQ(v2coinbaseTx.ins[0].script.getBlockHeight(), 37336)
+    })
   })
 
   describe(' - Transaction.getTotalOutValue()', function() {

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -80,6 +80,20 @@ describe('Transaction ', function() {
       T(v2coinbaseTx)
       EQ(v2coinbaseTx.ins[0].script.getBlockHeight(), 37336)
     })
+
+    it(' > parse transaction with version of 0', function() {
+      // https://helloblock.io/testnet/transactions/f1ebaf4604158a8a385cb55d1c0ca5efde98ab2d6f92bc667a02485f258c064e
+      var hex = '000000000100eb1d909b9f297fa7f72dc7d7298f19d5454c1cae28d7463f150a60aa2814d9010000006a47304402207413f23d980d48ba4855126ab8fc896fdeeb7752cd9c76a2054a696a5a6137cc02201a674d6cfd32668b9ac4c50ca853975a085f724cb92e95a189610e686e7f3204012103ac81c3203de55b31478da413d9bb68b99dc8e33176f9f48e5efcc0900bb41b4affffffff024e61bc00000000001976a914cdf39308e3b7ad69de09e1e4d99e036905a4289688aca2583905000000001976a914a2e4f051244a24e469d28f076fec1db4f79512b788ac00000000'
+      var buf = convBin(hex, { in : 'hex',
+        out: 'buffer'
+      })
+      var test = Transaction.deserialize(buf, 1)
+      debugger
+      EQ(convBin(test.serialize(), { in : 'bytes',
+        out: 'hex'
+      }), hex)
+    })
+
   })
 
   describe(' - Transaction.getTotalOutValue()', function() {


### PR DESCRIPTION
Tx Version can sometimes be 0. Need to be able to parse those txs too

Example with version 0

https://helloblock.io/testnet/transactions/f1ebaf4604158a8a385cb55d1c0ca5efde98ab2d6f92bc667a02485f258c064e
