### PR TITLE
Allow to limit the number of inputs/outputs

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -458,13 +458,16 @@ Parser.prototype.readVarRaw = function readVarRaw() {
 // Second argument txCount is optional; It indicates
 // the number of the transactions that you expect to
 // parse. The default number is 1
-Transaction.deserialize = function(buf, txCount) {
+Transaction.deserialize = function(buf, txCount, options) {
+  options || (options = {})
+
   if (!Buffer.isBuffer(buf)) {
     buf = binConv(buf, {
       out: 'buffer'
     });
   }
 
+  var limits = options.limits || {}
   var s = new Parser(buf)
 
   if (!txCount) {
@@ -489,6 +492,11 @@ Transaction.deserialize = function(buf, txCount) {
     var inB = s.readVarRaw()
     doc.serialized.push(inB)
     var inputCount = new Parser(inB).readVarInt()
+
+    if (limits.inputs && inputCount > limits.inputs) {
+      return false
+    }
+
     for (var i = 0; i < inputCount; i++) {
       var data = {}
       data.outpoint = {}
@@ -534,6 +542,11 @@ Transaction.deserialize = function(buf, txCount) {
     var outB = s.readVarRaw()
     doc.serialized.push(outB)
     var outputCount = new Parser(outB).readVarInt()
+
+    if (limits.outputs && outputCount > limits.outputs) {
+      return false
+    }
+
     for (var i = 0; i < outputCount; i++) {
       var data = {}
       var value = s.raw(8)


### PR DESCRIPTION
Without that, deserializing user-provided transactions could allow for a DoS attack by specifying a huge input/output count.
